### PR TITLE
Set up Q&A Thread pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import { BottomNavbar } from './components/BottomNavbar/BottomNavbar';
 import { StudyGroupPage } from './pages/study-group/StudyGroupPage';
 import { VirtualGroupPage } from './pages/virtual-group/VirtualGroupPage';
 import { QAThreadPage } from './pages/qa-thread/QAThreadPage';
+import { QAThreadModulePage } from './pages/qa-thread/module/QAThreadModulePage';
 import { DashboardPage } from './pages/dashboard/DashboardPage';
 import { LoginPage } from './pages/login/LoginPage';
 import { TemplatePage } from './pages/template/TemplatePage';
@@ -52,6 +53,9 @@ const AppComponent = ({ checkUserSession, currentUser }) => {
           />
           <Route path="/virtual-group-module">
             <VirtualGroupPageModule />
+          </Route>
+          <Route path="/qa-thread-module">
+            <QAThreadModulePage />
           </Route>
         </Switch>
         <BottomNavbar />

--- a/src/components/QAThreadCard/QAThreadCard.jsx
+++ b/src/components/QAThreadCard/QAThreadCard.jsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import { Typography } from "@material-ui/core";
+import { Card, CardActions } from "@material-ui/core";
+import { Box } from "@material-ui/core";
+import { Paper } from "@material-ui/core";
+import { Grid } from "@material-ui/core";
+import { Button } from "@material-ui/core";
+
+const componentStyles = makeStyles({
+  card: {
+    height: 200,
+    width: 175,
+    marginRight: 25,
+  },
+  cardContent: {
+    margin: 8,
+    overflow: "hidden",
+    padding: 8,
+  },
+  listItem: {
+    marginBottom: 10,
+    padding: 8,
+  },
+  listItemContent: {
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "space-between",
+  },
+});
+
+const ThreadPortraitCard = () => {
+  const componentClasses = componentStyles();
+  return (
+    <Card variant="outlined" className={componentClasses.card}>
+      <Box
+        width={1}
+        className={componentClasses.cardContent}
+        height={0.65}
+        m="5px"
+      >
+        <Box textOverflow="ellipsis">
+          <Typography variant="body1">Task name</Typography>
+        </Box>
+        <Box overflow="hidden">
+          <Typography component="p" variant="caption">
+            Current question
+          </Typography>
+        </Box>
+      </Box>
+      <CardActions disableSpacing>
+        <Button fullWidth>View</Button>
+      </CardActions>
+    </Card>
+  );
+};
+
+const ThreadLandscapeCard = () => {
+  const componentClasses = componentStyles();
+  return (
+    <Box component={Paper} className={componentClasses.listItem}>
+      <Grid container alignItems="center" spacing={1} justify="space-between">
+        <Grid item xs={8} md={9}>
+          <Box width={1} className={componentClasses.listItemContent}>
+            <Box width={1}>
+              <Typography variant="body1">Task name</Typography>
+            </Box>
+            <Box width={1}>
+              <Typography variant="caption" component="p">
+                Active questions: ...
+              </Typography>
+            </Box>
+          </Box>
+        </Grid>
+        <Grid item xs={3} md={1}>
+          <Button size="small" fullWidth>
+            View
+          </Button>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export const QAThreadCard = ({ modulePage }) => {
+  return (
+    <div>
+      {modulePage ? <ThreadLandscapeCard /> : <ThreadPortraitCard />}
+    </div>
+  );
+};

--- a/src/components/QAThreadModule/QAThreadModule.jsx
+++ b/src/components/QAThreadModule/QAThreadModule.jsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+import { makeStyles } from "@material-ui/core/styles";
+import { Typography } from "@material-ui/core";
+import { Box } from "@material-ui/core";
+import { Button, IconButton } from "@material-ui/core";
+import { ExpandMore, ExpandLess } from "@material-ui/icons";
+import { Collapse } from "@material-ui/core";
+
+import { QAThreadCard } from "../../components/QAThreadCard/QAThreadCard";
+
+const componentStyles = makeStyles({
+  item: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    marginBottom: 10,
+  },
+  itemHeader: {
+    display: "flex",
+    justifyContent: "flex-start",
+    alignItems: "center",
+  },
+  itemContent: {
+    margin: "10px 0px",
+    paddingBottom: 15,
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    "&::-webkit-scrollbar": {
+      height: "6px",
+    },
+    "&::-webkit-scrollbar-track": {
+      background: "transparent",
+    },
+    "&::-webkit-scrollbar-thumb:hover": {
+      borderRadius: 8,
+      background: "#421cf8",
+    },
+  },
+});
+
+export const QAThreadModule = () => {
+  const componentClasses = componentStyles();
+
+  const [open, setOpen] = React.useState(true);
+  const handleClick = () => {
+    setOpen(!open);
+  };
+
+  return (
+    <Box
+      width={1}
+      maxHeight={0.65}
+      alignItems="flex-start"
+      className={componentClasses.item}
+    >
+      <Box width={1} className={componentClasses.itemHeader}>
+        <IconButton onClick={handleClick}>
+          {open ? <ExpandLess /> : <ExpandMore />}
+        </IconButton>
+        <Button component={NavLink} to="/qa-thread-module">
+          <Typography variant="body1">MOD1001</Typography>
+        </Button>
+      </Box>
+      <Box width={1}>
+        <Collapse in={open} timeout="auto" unmountOnExit>
+          <Box overflow="auto" className={componentClasses.itemContent}>
+            <QAThreadCard />
+            <QAThreadCard />
+            <QAThreadCard />
+            <QAThreadCard />
+            <QAThreadCard />
+            <QAThreadCard />
+            <QAThreadCard />
+            <QAThreadCard />
+          </Box>
+        </Collapse>
+      </Box>
+    </Box>
+  );
+};

--- a/src/components/VirtualGroupCardModule/VirtualGroupCardModule.jsx
+++ b/src/components/VirtualGroupCardModule/VirtualGroupCardModule.jsx
@@ -14,7 +14,6 @@ const componentStyles = makeStyles({
   },
   groupPicture: {},
   itemContent: {
-    borderBottom: "1px solid rgba(0, 0, 0, 0.35)",
     marginLeft: 5,
     paddingBottom: 5,
   },

--- a/src/components/VirtualGroupModule/VirtualGroupModule.jsx
+++ b/src/components/VirtualGroupModule/VirtualGroupModule.jsx
@@ -1,13 +1,15 @@
 import React, { Component } from "react";
-import { theme } from "../../styles/material.styles";
 import { NavLink } from "react-router-dom";
 import { makeStyles, ThemeProvider } from "@material-ui/core/styles";
 import { Typography } from "@material-ui/core";
 import { Button, IconButton } from "@material-ui/core";
-import { VirtualGroupCard } from "../../components/VirtualGroupCard/VirtualGroupCard";
 import { Box } from "@material-ui/core";
 import { ExpandMore, ExpandLess } from "@material-ui/icons";
 import { Collapse } from "@material-ui/core";
+
+import { theme } from "../../styles/material.styles";
+
+import { VirtualGroupCard } from "../../components/VirtualGroupCard/VirtualGroupCard";
 
 const componentStyles = makeStyles({
   item: {
@@ -40,13 +42,14 @@ const componentStyles = makeStyles({
     },
     "&::-webkit-scrollbar-thumb:hover": {
       borderRadius: 8,
-      background: '#421cf8',
+      background: "#421cf8",
     },
   },
 });
 
 export const VirtualGroupModule = () => {
   const component = componentStyles();
+
   const [open, setOpen] = React.useState(true);
   const handleClick = () => {
     setOpen(!open);
@@ -67,11 +70,13 @@ export const VirtualGroupModule = () => {
           <Button component={NavLink} to="/virtual-group-module">
             <Typography variant="body1">MOD1001</Typography>
           </Button>
-      </div>
         </div>
+      </div>
       <Box width={1}>
         <Collapse in={open} timeout="auto" unmountOnExit>
           <Box overflow="auto" className={component.itemContent}>
+            <VirtualGroupCard />
+            <VirtualGroupCard />
             <VirtualGroupCard />
             <VirtualGroupCard />
             <VirtualGroupCard />

--- a/src/components/YourQAThread/YourQAThread.jsx
+++ b/src/components/YourQAThread/YourQAThread.jsx
@@ -1,0 +1,51 @@
+import React, { Component } from "react";
+import { makeStyles, theme } from "@material-ui/core/styles";
+import { materialStyles } from "../../styles/material.styles";
+import { Typography } from "@material-ui/core";
+import { Button } from "@material-ui/core";
+import { Box } from "@material-ui/core";
+import { Paper } from "@material-ui/core";
+import { Grid } from "@material-ui/core";
+
+const componentStyles = makeStyles({
+  item: {
+    display: "flex",
+    flexDirection: "column",
+    background: "white",
+    borderBottom: "0.5px solid rgba(0, 0, 0, 0.35)",
+  },
+});
+
+export const YourQAThread = () => {
+  const materialClasses = materialStyles();
+  const componentClasses = componentStyles();
+  
+  return (
+    <Box component={Paper} className={materialClasses.paper} mb="5px" height={0.45} width={1}>
+      <Box width={1}>
+        <Typography variant="button">MOD1001</Typography>
+      </Box>
+      <Grid
+        container
+        spacing={1}
+        m="5px"
+        p="5px"
+        display="flex"
+        justify="space-between"
+        alignItems="center"
+        width={1}
+      >
+        <Grid item md={9}>
+          <Typography component="p" variant="body1">
+            Task name
+          </Typography>
+        </Grid>
+        <Grid item md={3}>
+          <Button size="small">
+            <Typography variant="button">View</Typography>
+          </Button>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};

--- a/src/components/YourQAThreadSmall/YourQAThreadSmall.jsx
+++ b/src/components/YourQAThreadSmall/YourQAThreadSmall.jsx
@@ -1,0 +1,52 @@
+import React, { Component } from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import { Typography } from "@material-ui/core";
+import { List, ListItem } from "@material-ui/core";
+import { Grid } from "@material-ui/core";
+
+const componentStyles = makeStyles({
+  root: {
+    backgroundColor: "white",
+    borderStyle: "solid",
+    borderWidth: 1,
+    borderColor: "rgba(0, 0, 0, .4)",
+    borderRadius: 5,
+    width: 332,
+  },
+});
+
+const Thread = () => {
+  return (
+    <div>
+      <ListItem button>
+        <Grid
+          container
+          direction="row"
+          justify="space-between"
+          alignItems="center"
+        >
+          <Grid item xs={8}>
+            <Typography variant="body1" noWrap>
+              Task name
+            </Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <Typography variant="button">MOD1001</Typography>
+          </Grid>
+        </Grid>
+      </ListItem>
+    </div>
+  );
+};
+
+export const YourQAThreadSmall = () => {
+  const component = componentStyles();
+  return (
+    <div>
+      <List className={component.root}>
+        <Thread />
+        <Thread />
+      </List>
+    </div>
+  );
+};

--- a/src/pages/qa-thread/QAThreadPage.jsx
+++ b/src/pages/qa-thread/QAThreadPage.jsx
@@ -1,11 +1,163 @@
-import React, { Component } from 'react';
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import { materialStyles } from "../../styles/material.styles";
+import { Typography } from "@material-ui/core";
+import { Box } from "@material-ui/core";
+import { Grid } from "@material-ui/core";
+import { Hidden } from "@material-ui/core";
+import { Button } from "@material-ui/core";
+import { Popper } from "@material-ui/core";
+import { ClickAwayListener } from "@material-ui/core";
 
-export class QAThreadPage extends Component {
-  render() {
-    return (
-      <div>
-        <h1>This is QAThreadPage</h1>
-      </div>
-    );
-  }
-}
+import { Searchbar } from "../../components/Searchbar/Searchbar";
+import { QAThreadModule } from "../../components/QAThreadModule/QAThreadModule";
+import { YourQAThread } from "../../components/YourQAThread/YourQAThread";
+import { YourQAThreadSmall } from "../../components/YourQAThreadSmall/YourQAThreadSmall";
+
+// temporary imports
+import { StudyGroup } from "../../models/StudyGroup";
+
+const liveThreadsStyles = makeStyles({
+  list: {
+    overflow: "auto",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    marginTop: 20,
+    "&::-webkit-scrollbar": {
+      display: "none",
+    },
+  },
+});
+
+const yourThreadsStyles = makeStyles({
+  list: {
+    height: 200,
+    margin: "20px 0px",
+    overflow: "auto",
+    alignItems: "flex-start",
+    flexDirection: "column",
+    "&::-webkit-scrollbar": {
+      display: "none",
+    },
+  },
+});
+
+export const QAThreadPage = () => {
+  const materialClasses = materialStyles();
+  const liveThreadsClasses = liveThreadsStyles();
+  const yourThreadsClasses = yourThreadsStyles();
+
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [open, setOpen] = React.useState(false);
+  const [anotherAnchorEl, setAnotherAnchorEl] = React.useState(null);
+  const [anotherOpen, setAnotherOpen] = React.useState(false);
+
+  const handleClick = (event) => {
+    setOpen((prev) => !prev);
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleAnotherClick = (event) => {
+    setAnotherOpen((prev) => !prev);
+    setAnotherAnchorEl(event.currentTarget);
+  };
+
+  const handleClickAway = () => {
+    setOpen(false);
+  };
+
+  const handleAnotherClickAway = () => {
+    setAnotherOpen(false);
+  };
+
+  return (
+    <Box className={materialClasses.root}>
+      <Hidden mdUp>
+        <Popper open={open} anchorEl={anchorEl} placement="bottom">
+          <YourQAThreadSmall />
+        </Popper>
+      </Hidden>
+      <Hidden mdUp>
+        <Popper
+          open={anotherOpen}
+          anchorEl={anotherAnchorEl}
+          placement="bottom"
+        >
+          <YourQAThreadSmall />
+        </Popper>
+      </Hidden>
+      <Grid container spacing={3} justify="space-between">
+        <Grid item xs={12} md={8}>
+          <Hidden mdUp>
+            <Box my="4px">
+              <ClickAwayListener onClickAway={handleClickAway}>
+                <Button
+                  onClick={handleClick}
+                  variant="outlined"
+                  fullWidth
+                  size="small"
+                >
+                  <Typography variant="button">Starred threads</Typography>
+                </Button>
+              </ClickAwayListener>
+            </Box>
+          </Hidden>
+          <Hidden mdUp>
+            <Box my="4px">
+              <ClickAwayListener onClickAway={handleAnotherClickAway}>
+                <Button
+                  onClick={handleAnotherClick}
+                  variant="outlined"
+                  fullWidth
+                  size="small"
+                >
+                  <Typography variant="button">Recent threads</Typography>
+                </Button>
+              </ClickAwayListener>
+            </Box>
+          </Hidden>
+          <Box>
+            <Searchbar searchOptions={StudyGroup.searchOptions} />
+          </Box>
+          <Box width={1} className={liveThreadsClasses.list}>
+            <QAThreadModule />
+            <QAThreadModule />
+            <QAThreadModule />
+            <QAThreadModule />
+            <QAThreadModule />
+          </Box>
+        </Grid>
+
+        <Hidden smDown>
+          <Grid item md={3}>
+            <Box my="10px">
+              <Typography variant="h6" align="center">
+                Starred threads
+              </Typography>
+            </Box>
+            <Box className={yourThreadsClasses.list}>
+              <YourQAThread />
+              <YourQAThread />
+              <YourQAThread />
+              <YourQAThread />
+              <YourQAThread />
+            </Box>
+            <Box my={2}>
+              <Typography variant="h6" align="center">
+                Recent threads
+              </Typography>
+            </Box>
+            <Box className={yourThreadsClasses.list}>
+              <YourQAThread />
+              <YourQAThread />
+              <YourQAThread />
+              <YourQAThread />
+              <YourQAThread />
+            </Box>
+          </Grid>
+        </Hidden>
+      </Grid>
+    </Box>
+  );
+};

--- a/src/pages/qa-thread/module/QAThreadModulePage.jsx
+++ b/src/pages/qa-thread/module/QAThreadModulePage.jsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import { Typography } from "@material-ui/core";
+import { Box } from "@material-ui/core";
+import { Grid } from "@material-ui/core";
+import { Hidden } from "@material-ui/core";
+import { Button } from "@material-ui/core";
+import { Popper } from "@material-ui/core";
+import { ClickAwayListener } from "@material-ui/core";
+
+import { materialStyles } from "../../../styles/material.styles";
+import { Searchbar } from "../../../components/Searchbar/Searchbar";
+import { YourQAThread } from "../../../components/YourQAThread/YourQAThread";
+import { YourQAThreadSmall } from "../../../components/YourQAThreadSmall/YourQAThreadSmall";
+import { QAThreadCard } from "../../../components/QAThreadCard/QAThreadCard";
+
+// temporary imports
+import { StudyGroup } from "../../../models/StudyGroup";
+
+const liveThreadsStyles = makeStyles({
+  list: {
+    overflow: "auto",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    marginTop: 20,
+    "&::-webkit-scrollbar": {
+      display: "none",
+    },
+  },
+});
+
+const yourThreadsStyles = makeStyles({
+  list: {
+    height: 200,
+    margin: "20px 0px",
+    overflow: "auto",
+    alignItems: "flex-start",
+    flexDirection: "column",
+    "&::-webkit-scrollbar": {
+      display: "none",
+    },
+  },
+});
+
+export const QAThreadModulePage = () => {
+  const materialClasses = materialStyles();
+  const liveThreadsClasses = liveThreadsStyles();
+  const yourThreadsClasses = yourThreadsStyles();
+
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [open, setOpen] = React.useState(false);
+  const [anotherAnchorEl, setAnotherAnchorEl] = React.useState(null);
+  const [anotherOpen, setAnotherOpen] = React.useState(false);
+
+  const handleClick = (event) => {
+    setOpen((prev) => !prev);
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleAnotherClick = (event) => {
+    setAnotherOpen((prev) => !prev);
+    setAnotherAnchorEl(event.currentTarget);
+  };
+
+  const handleClickAway = () => {
+    setOpen(false);
+  };
+
+  const handleAnotherClickAway = () => {
+    setAnotherOpen(false);
+  };
+
+  return (
+    <Box className={materialClasses.root}>
+      <Hidden mdUp>
+        <Popper open={open} anchorEl={anchorEl} placement="bottom">
+          <YourQAThreadSmall />
+        </Popper>
+      </Hidden>
+      <Hidden mdUp>
+        <Popper
+          open={anotherOpen}
+          anchorEl={anotherAnchorEl}
+          placement="bottom"
+        >
+          <YourQAThreadSmall />
+        </Popper>
+      </Hidden>
+      <Grid container spacing={3} justify="space-between">
+        <Grid item xs={12} md={8}>
+          <Typography variant="h4" align="center">
+            MOD1001
+          </Typography>
+          <Hidden mdUp>
+            <Box my="4px">
+              <ClickAwayListener onClickAway={handleClickAway}>
+                <Button
+                  onClick={handleClick}
+                  variant="outlined"
+                  fullWidth
+                  size="small"
+                >
+                  <Typography variant="button">Starred threads</Typography>
+                </Button>
+              </ClickAwayListener>
+            </Box>
+          </Hidden>
+          <Hidden mdUp>
+            <Box my="4px">
+              <ClickAwayListener onClickAway={handleAnotherClickAway}>
+                <Button
+                  onClick={handleAnotherClick}
+                  variant="outlined"
+                  fullWidth
+                  size="small"
+                >
+                  <Typography variant="button">Recent threads</Typography>
+                </Button>
+              </ClickAwayListener>
+            </Box>
+          </Hidden>
+          <Grid container height={1} spacing={1}>
+            <Grid item xs={12}>
+              <Searchbar searchOptions={StudyGroup.searchOptions} />
+            </Grid>
+            <Grid item xs={12} wrap="nowrap">
+              <Box width={1} className={liveThreadsClasses.list}>
+                <QAThreadCard modulePage />
+                <QAThreadCard modulePage />
+                <QAThreadCard modulePage />
+                <QAThreadCard modulePage />
+              </Box>
+            </Grid>
+          </Grid>
+        </Grid>
+        <Hidden smDown>
+          <Grid item md={3}>
+            <Box my="10px">
+              <Typography variant="h6" align="center">
+                Starred threads
+              </Typography>
+            </Box>
+            <Box className={yourThreadsClasses.list}>
+              <YourQAThread />
+              <YourQAThread />
+              <YourQAThread />
+              <YourQAThread />
+              <YourQAThread />
+            </Box>
+            <Box my={2}>
+              <Typography variant="h6" align="center">
+                Recent threads
+              </Typography>
+            </Box>
+            <Box className={yourThreadsClasses.list}>
+              <YourQAThread />
+              <YourQAThread />
+              <YourQAThread />
+              <YourQAThread />
+              <YourQAThread />
+            </Box>
+          </Grid>
+        </Hidden>
+      </Grid>
+    </Box>
+  );
+};

--- a/src/pages/virtual-group/VirtualGroupPage.jsx
+++ b/src/pages/virtual-group/VirtualGroupPage.jsx
@@ -1,10 +1,5 @@
-import React, { Component } from "react";
+import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
-import {
-  createMuiTheme,
-  responsiveFontSizes,
-  ThemeProvider,
-} from "@material-ui/core/styles";
 import { materialStyles } from "../../styles/material.styles";
 import { Grid } from "@material-ui/core";
 import { Hidden } from "@material-ui/core";
@@ -20,21 +15,16 @@ import { YourGroupsSmall } from "../../components/YourVirtualGroupsSmall/YourVir
 import { VirtualGroupModule } from "../../components/VirtualGroupModule/VirtualGroupModule";
 import { YourGroupCard } from "../../components/YourVirtualGroupCard/YourVirtualGroupCard";
 
-let muiTheme = createMuiTheme();
-muiTheme = responsiveFontSizes(muiTheme);
-
 const recruitingGroupStyles = makeStyles({
   header: {
     margin: "10px 0px",
-    paddingRight: 0,
-    flexDirection: "row",
   },
   list: {
     overflow: "auto",
     display: "flex",
     flexDirection: "column",
     alignItems: "flex-start",
-    height: 492,
+    height: 488,
     "&::-webkit-scrollbar": {
       display: "none",
     },
@@ -45,8 +35,8 @@ const yourGroupStyles = makeStyles({
   list: {
     overflow: "auto",
     alignItems: "flex-start",
-    flexDirection: "row",
-    height: 492,
+    flexDirection: "column",
+    height: 400,
     "&::-webkit-scrollbar": {
       display: "none",
     },
@@ -74,78 +64,71 @@ export const VirtualGroupPage = () => {
   };
 
   return (
-    <ThemeProvider theme={muiTheme}>
-      <div className={styles.pageMargin}>
-        <Grid container spacing={4} justify="space-between">
-          <Grid item md={8} xs={12}>
-            <Hidden mdUp>
-              <Popper
-                open={open}
-                anchorEl={anchorEl}
-                display
-                placement="bottom"
-              >
-                <YourGroupsSmall />
-              </Popper>
-            </Hidden>
-            <Grid
-              container
-              className={recruitingGroups.header}
-              justify="space-between"
-            >
-              <Grid item xs={12}>
-                <Typography variant="h6" align="left">
-                  RECRUITING GROUPS
-                </Typography>
-              </Grid>
-              <Hidden mdUp>
-                <Grid item xs={12} justify="flex-end">
-                  <ClickAwayListener onClickAway={handleClickAway}>
-                    <Button
-                      onClick={handleClick}
-                      variant="outlined"
-                      fullWidth
-                      size="small"
-                    >
-                      <Typography variant="button">Your groups</Typography>
-                    </Button>
-                  </ClickAwayListener>
-                </Grid>
-              </Hidden>
+    <Box className={styles.root}>
+      <Grid container spacing={4} justify="space-between">
+        <Grid item md={8} xs={12}>
+          <Hidden mdUp>
+            <Popper open={open} anchorEl={anchorEl} placement="bottom">
+              <YourGroupsSmall />
+            </Popper>
+          </Hidden>
+          <Grid
+            container
+            className={recruitingGroups.header}
+            justify="space-between"
+          >
+            <Grid item xs={12}>
+              <Typography variant="h6" align="left">
+                RECRUITING GROUPS
+              </Typography>
             </Grid>
-            <Box component="form" className={styles.searchBar}>
-              <InputBase
-                className={styles.fix}
-                placeholder="Search module or group"
-              />
-              <IconButton size="small" disableRipple>
-                <Search />
-              </IconButton>
+            <Hidden mdUp>
+              <Grid item xs={12} justify="flex-end">
+                <ClickAwayListener onClickAway={handleClickAway}>
+                  <Button
+                    onClick={handleClick}
+                    variant="outlined"
+                    fullWidth
+                    size="small"
+                  >
+                    <Typography variant="button">Your groups</Typography>
+                  </Button>
+                </ClickAwayListener>
+              </Grid>
+            </Hidden>
+          </Grid>
+          <Box component="form" className={styles.searchBar}>
+            <InputBase
+              className={styles.fix}
+              placeholder="Search module or group"
+            />
+            <IconButton size="small" disableRipple>
+              <Search />
+            </IconButton>
+          </Box>
+          <Box width={1} className={recruitingGroups.list} disablePadding>
+            <VirtualGroupModule />
+            <VirtualGroupModule />
+            <VirtualGroupModule />
+            <VirtualGroupModule />
+            <VirtualGroupModule />
+          </Box>
+        </Grid>
+        <Hidden smDown>
+          <Grid item md={3}>
+            <Box className={yourGroups.header}>
+              <Typography variant="h6" align="center">
+                Your groups
+              </Typography>
             </Box>
-            <Box width={1} className={recruitingGroups.list} disablePadding>
-              <VirtualGroupModule />
-              <VirtualGroupModule />
-              <VirtualGroupModule />
-              <VirtualGroupModule />
-              <VirtualGroupModule />
+            <Box className={yourGroups.list}>
+              <YourGroupCard />
+              <YourGroupCard />
+              <YourGroupCard />
             </Box>
           </Grid>
-          <Hidden smDown>
-            <Grid item md={3}>
-              <Box className={yourGroups.header}>
-                <Typography variant="h6" align="center">
-                  Your groups
-                </Typography>
-              </Box>
-              <Box className={yourGroups.list}>
-                <YourGroupCard />
-                <YourGroupCard />
-                <YourGroupCard />
-              </Box>
-            </Grid>
-          </Hidden>
-        </Grid>
-      </div>
-    </ThemeProvider>
+        </Hidden>
+      </Grid>
+    </Box>
   );
 };

--- a/src/pages/virtual-group/VirtualGroupPageModule.jsx
+++ b/src/pages/virtual-group/VirtualGroupPageModule.jsx
@@ -1,11 +1,6 @@
-import React, { Component } from "react";
+import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { materialStyles } from "../../styles/material.styles";
-import {
-  createMuiTheme,
-  responsiveFontSizes,
-  ThemeProvider,
-} from "@material-ui/core/styles";
 import { Grid } from "@material-ui/core";
 import { Hidden } from "@material-ui/core";
 import { Typography } from "@material-ui/core";
@@ -19,9 +14,6 @@ import { ClickAwayListener } from "@material-ui/core";
 import { YourGroupsSmall } from "../../components/YourVirtualGroupsSmall/YourVirtualGroupsSmall";
 import { VirtualGroupCardModule } from "../../components/VirtualGroupCardModule/VirtualGroupCardModule";
 import { YourGroupCard } from "../../components/YourVirtualGroupCard/YourVirtualGroupCard";
-
-let muiTheme = createMuiTheme();
-muiTheme = responsiveFontSizes(muiTheme);
 
 const recruitingGroupStyles = makeStyles({
   header: {
@@ -74,79 +66,77 @@ export const VirtualGroupPageModule = () => {
   };
 
   return (
-    <ThemeProvider theme={muiTheme}>
-      <div className={styles.pageMargin}>
-        <Grid container spacing={4} justify="space-between">
-          <Grid item md={8} xs={12}>
-            <Hidden mdUp>
-              <Popper
-                open={open}
-                anchorEl={anchorEl}
-                display
-                placement="bottom-end"
-              >
-                <YourGroupsSmall />
-              </Popper>
-            </Hidden>
-            <Grid
-              container
-              className={recruitingGroups.header}
-              justify="space-between"
+    <Box className={styles.root}>
+      <Grid container spacing={4} justify="space-between">
+        <Grid item md={8} xs={12}>
+          <Hidden mdUp>
+            <Popper
+              open={open}
+              anchorEl={anchorEl}
+              display
+              placement="bottom-end"
             >
-              <Grid item xs={12}>
-                <Typography variant="h6" align="left">
-                  RECRUITING GROUPS
-                </Typography>
-              </Grid>
-              <Hidden mdUp>
-                <Grid item xs={12} justify="flex-end">
-                  <ClickAwayListener onClickAway={handleClickAway}>
-                    <Button
-                      onClick={handleClick}
-                      variant="outlined"
-                      fullWidth
-                      size="small"
-                    >
-                      <Typography variant="button">Your groups</Typography>
-                    </Button>
-                  </ClickAwayListener>
-                </Grid>
-              </Hidden>
+              <YourGroupsSmall />
+            </Popper>
+          </Hidden>
+          <Grid
+            container
+            className={recruitingGroups.header}
+            justify="space-between"
+          >
+            <Grid item xs={12}>
+              <Typography variant="h6" align="left">
+                RECRUITING GROUPS
+              </Typography>
             </Grid>
-            <Box component="form" className={styles.searchBar}>
-              <InputBase
-                className={styles.fix}
-                placeholder="Search module or group"
-              />
-              <IconButton size="small" disableRipple>
-                <Search />
-              </IconButton>
+            <Hidden mdUp>
+              <Grid item xs={12} justify="flex-end">
+                <ClickAwayListener onClickAway={handleClickAway}>
+                  <Button
+                    onClick={handleClick}
+                    variant="outlined"
+                    fullWidth
+                    size="small"
+                  >
+                    <Typography variant="button">Your groups</Typography>
+                  </Button>
+                </ClickAwayListener>
+              </Grid>
+            </Hidden>
+          </Grid>
+          <Box component="form" className={styles.searchBar}>
+            <InputBase
+              className={styles.fix}
+              placeholder="Search module or group"
+            />
+            <IconButton size="small" disableRipple>
+              <Search />
+            </IconButton>
+          </Box>
+          <Box className={recruitingGroups.list} disablePadding>
+            <VirtualGroupCardModule />
+            <VirtualGroupCardModule />
+            <VirtualGroupCardModule />
+            <VirtualGroupCardModule />
+            <VirtualGroupCardModule />
+            <VirtualGroupCardModule />
+          </Box>
+        </Grid>
+        <Hidden smDown>
+          <Grid item md={3}>
+            <Box className={yourGroups.header}>
+              <Typography variant="h6" align="center">
+                Your groups
+              </Typography>
             </Box>
-            <Box className={recruitingGroups.list} disablePadding>
-              <VirtualGroupCardModule />
-              <VirtualGroupCardModule />
-              <VirtualGroupCardModule />
-              <VirtualGroupCardModule />
-              <VirtualGroupCardModule />
-              <VirtualGroupCardModule />
+            <Box className={yourGroups.list}>
+              <YourGroupCard />
+              <YourGroupCard />
+              <YourGroupCard />
             </Box>
           </Grid>
-          <Hidden smDown>
-            <Grid item md={3}>
-              <Box className={yourGroups.header}>
-                <Typography variant="h6" align="center">
-                  Your groups
-                </Typography>
-              </Box>
-              <Box className={yourGroups.list}>
-                <YourGroupCard />
-                <YourGroupCard />
-                <YourGroupCard />
-              </Box>
-            </Grid>
-          </Hidden>
-        </Grid>
-      </div>
-    </ThemeProvider>
+        </Hidden>
+      </Grid>
+    </Box>
   );
 };


### PR DESCRIPTION
## What?
Set up Q&A Thread main page
Set up Q&A Thread module page
## Why?
Feature enhancement for #17 and _see open Q&A Threads_
## How?
Create a template for the pages. The pages consist of two sections: Live Threads section on the left and Your Threads section on the right. Your Threads section is the same on both pages. On mobile screens, the Your Threads section is reduced to a subsection of the Live Threads section which can be accessed by clicking on either the 'STARRED THREADS' button or the 'RECENT THREADS' buttons on the top of the page. The Live Threads section for each page is as follows:-

**Main page**
Contains a search bar, followed by a list of live Q&A threads categorised by module. On mobile screens, the two Your Threads buttons can be seen above the search bar. 

_Live threads list_ - each list item represents a module. Clients may click on the module code to access the module page. The item may be expanded or collapsed by clicking on the expand icon on the left of the module code. When expanded, the item shows a horizontal list of cards each representing a live Q&A thread. The list items are expanded when the client first visits the page.

**Module page**
Contains module code as title and a search bar, followed by a list of live Q&A threads under the module. On mobile screens, the two Your Threads buttons can be seen above the search bar. 

_Live threads list_ - each list item represents a live thread and comprises the task name, active questions and a 'VIEW' button.
## Testing?
N/A
## Screenshots (optional)
**Template pages on HiDPI screen laptop**
Main page
![localhost_3000_qa-thread(Laptop with HiDPI screen) (1)](https://user-images.githubusercontent.com/65291543/84983827-2bf0b100-b16c-11ea-92ec-8376911f906e.png)

Module page
![localhost_3000_qa-thread(Laptop with HiDPI screen) (2)](https://user-images.githubusercontent.com/65291543/84983865-43c83500-b16c-11ea-8963-ea90f56bdd57.png)

**Template pages on iPhone X**
Main page
![localhost_3000_qa-thread(iPhone X)](https://user-images.githubusercontent.com/65291543/84983707-e7651580-b16b-11ea-9c0d-b788c36457d9.png)

Module page
![localhost_3000_qa-thread(iPhone X) (2)](https://user-images.githubusercontent.com/65291543/84983765-0663a780-b16c-11ea-8216-e0bcca5d21e5.png)

Drop-down list of Your Threads 
![localhost_3000_qa-thread(iPhone X)(3)](https://user-images.githubusercontent.com/65291543/84983801-167b8700-b16c-11ea-8033-79cf2c5781f5.png)
## Anything Else?
A 'CREATE' button will be added next to the search bar to enable the Create Thread functionality i.e. feature enhancement #23.
