### PR TITLE
Integrate user's modules in study group page

### DIFF
--- a/src/components/AddModuleDialog/AddModuleForm.jsx
+++ b/src/components/AddModuleDialog/AddModuleForm.jsx
@@ -108,8 +108,6 @@ const AddModuleFormComponent = ({
               control={control}
               rules={{
                 required: 'Module is required',
-                validate: (value) =>
-                  value.length > 0 || 'Select at least one module',
               }}
             />
             {errors.modules && (

--- a/src/components/StudyGroupDialog/StudyGroupDialog.jsx
+++ b/src/components/StudyGroupDialog/StudyGroupDialog.jsx
@@ -68,6 +68,7 @@ const StudyGroupDialogComponent = ({ currentUser, createSuccess }) => {
         open={open}
         onClose={handleClose}
         fullScreen={fullScreen}
+        fullWidth
         aria-labelledby="form-dialog-title"
         disableBackdropClick
       >

--- a/src/components/StudyGroupDialog/StudyGroupForm.jsx
+++ b/src/components/StudyGroupDialog/StudyGroupForm.jsx
@@ -2,10 +2,11 @@ import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
 import { useForm, Controller } from 'react-hook-form';
+import { DevTool } from 'react-hook-form-devtools';
 import { createStructuredSelector } from 'reselect';
 
 import { StudyGroup } from '../../models/StudyGroup';
-import { modules } from '../../models/Module';
+import { Module } from '../../models/Module';
 import {
   createGroupStart,
   clearGroupError,
@@ -51,56 +52,64 @@ const StudyGroupFormComponent = ({
   clearCreateSuccess,
 }) => {
   const classes = useStyles();
-  const [startTime, setStartTime] = useState(new moment());
-  const [endTime, setEndTime] = useState(new moment().add(1, 'hours'));
-  const [capacity, setCapacity] = React.useState(4);
+  const [capacity, setCapacity] = useState(4);
+  const now = moment();
   const maxDate = moment().add(5, 'days');
   const {
     register,
     handleSubmit,
     errors,
-    setError,
-    clearError,
     control,
     setValue,
+    setError,
+    watch,
   } = useForm({
     mode: 'onChange',
     reValidateMode: 'onChange',
     defaultValues: {
-      module: modules.find((module) => module.id === 'CS2030'),
+      module: null,
       capacity: 4,
-      startTime: startTime,
-      endTime: endTime,
+      startTime: moment(),
+      endTime: moment().add(1, 'hours'),
     },
   });
 
-  const now = moment();
+  const modules = currentUser.modules.map((moduleCode) =>
+    Module.getModuleById(moduleCode)
+  );
 
   const handleCapacityChange = (event) => {
     setCapacity(event.target.value);
     setValue('capacity', event.target.value);
   };
 
+  const watchStart = watch('startTime');
+  const watchEnd = watch('endTime');
+
   const handleStartTimeChange = (event) => {
-    clearError('startTime');
-    setStartTime(event);
-    setValue('startTime', event);
-    if (startTime.isBefore(now)) {
-      setError('startTime', 'invalid', 'Start time is already passed');
-    } else if (startTime.isAfter(endTime)) {
-      setError('startTime', 'invalid', 'Start time is after the end time');
+    const startTime = event[0];
+    if (startTime.endOf('minute').isBefore(now)) {
+      setError('startTime', 'beforeNow', 'Start time is already passed');
+    } else if (
+      startTime.isAfter(watchEnd) ||
+      startTime.endOf('minute').isSame(watchEnd.endOf('minute'))
+    ) {
+      setError('startTime', 'startAfterEnd', 'Start time must before end time');
     }
+    return startTime;
   };
 
   const handleEndTimeChange = (event) => {
-    clearError('endTime');
-    setEndTime(event);
-    setValue('endTime', event);
-    if (endTime.isBefore(now)) {
-      setError('endTime', 'invalid', 'End time is already passed');
-    } else if (endTime.isBefore(startTime)) {
-      setError('endTime', 'invalid', 'End time is before the start time');
+    const endTime = event[0];
+    if (endTime.endOf('minute').isBefore(now)) {
+      setError('endTime', 'beforeNow', 'End time is already passed');
+    } else if (
+      endTime.isBefore(watchStart) ||
+      watchStart.endOf('minute').isSame(endTime.endOf('minute'))
+    ) {
+      setError('endTime', 'endBeforeStart', 'End time must after start time');
     }
+    return endTime;
   };
 
   const onSubmit = async (data) => {
@@ -109,14 +118,11 @@ const StudyGroupFormComponent = ({
       data: data,
       currentUserId: currentUser.id,
     });
-    console.log(studyGroup);
     await createGroupStart(studyGroup);
   };
 
   useEffect(() => {
     register({ name: 'capacity' }); // custom register react select
-    register({ name: 'startTime' });
-    register({ name: 'endTime' });
   }, [register]);
 
   useEffect(
@@ -251,38 +257,46 @@ const StudyGroupFormComponent = ({
             )}
           </Grid>
           <Grid xs={12} sm={6} item>
-            <DateTimePicker
-              format={dateTimeFormat}
-              className={classes.form}
-              label="From"
-              inputVariant="outlined"
-              value={startTime}
-              onChange={handleStartTimeChange}
-              disablePast
-              maxDate={maxDate}
-              required
+            <Controller
               name="startTime"
-              error={!!errors.startTime}
-              //inputRef={register({ required: 'Start time is required' })}
+              control={control}
+              onChange={handleStartTimeChange}
+              as={
+                <DateTimePicker
+                  autoOk
+                  format={dateTimeFormat}
+                  className={classes.form}
+                  onChange={() => {}}
+                  label="From"
+                  inputVariant="outlined"
+                  disablePast
+                  maxDate={maxDate}
+                  required
+                />
+              }
             />
             {errors.startTime && (
               <ErrorMessage errorMessage={errors.startTime.message} />
             )}
           </Grid>
           <Grid xs={12} sm={6} item>
-            <DateTimePicker
-              format={dateTimeFormat}
-              className={classes.form}
-              label="Until"
-              inputVariant="outlined"
-              value={endTime}
-              onChange={handleEndTimeChange}
-              maxDate={maxDate}
-              disablePast
-              required
+            <Controller
               name="endTime"
-              error={!!errors.endTime}
-              //inputRef={register({ required: 'End time is required' })}
+              control={control}
+              onChange={handleEndTimeChange}
+              as={
+                <DateTimePicker
+                  autoOk
+                  format={dateTimeFormat}
+                  className={classes.form}
+                  onChange={() => {}}
+                  label="Until"
+                  inputVariant="outlined"
+                  disablePast
+                  maxDate={maxDate}
+                  required
+                />
+              }
             />
             {errors.endTime && (
               <ErrorMessage errorMessage={errors.endTime.message} />
@@ -311,6 +325,7 @@ const StudyGroupFormComponent = ({
           </Grid>
         </Grid>
       </form>
+      <DevTool control={control} />
     </Box>
   );
 };

--- a/src/components/StudyGroupDialog/StudyGroupForm.jsx
+++ b/src/components/StudyGroupDialog/StudyGroupForm.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
 import { useForm, Controller } from 'react-hook-form';
-import { DevTool } from 'react-hook-form-devtools';
 import { createStructuredSelector } from 'reselect';
 
 import { StudyGroup } from '../../models/StudyGroup';
@@ -325,7 +324,6 @@ const StudyGroupFormComponent = ({
           </Grid>
         </Grid>
       </form>
-      <DevTool control={control} />
     </Box>
   );
 };

--- a/src/components/shared/CustomSnackbar.jsx
+++ b/src/components/shared/CustomSnackbar.jsx
@@ -21,7 +21,7 @@ export const CustomSnackbar = ({ variant, message }) => {
   const classes = useStyles();
   const [open, setOpen] = React.useState(true);
 
-  const handleClose = (event, reason) => {
+  const handleClose = (_, reason) => {
     if (reason === 'clickaway') {
       return;
     }
@@ -31,7 +31,7 @@ export const CustomSnackbar = ({ variant, message }) => {
 
   return (
     <div className={classes.root}>
-      <Snackbar open={open} autoHideDuration={4000} onClose={handleClose}>
+      <Snackbar open={open} autoHideDuration={3000} onClose={handleClose}>
         <Alert onClose={handleClose} severity={variant}>
           {message}
         </Alert>

--- a/src/components/shared/InfoAlert.jsx
+++ b/src/components/shared/InfoAlert.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { Typography } from '@material-ui/core';
+import { Alert, AlertTitle } from '@material-ui/lab';
+
+export const InfoAlert = ({ alertTitle, alertText, route, pageName }) => {
+  return (
+    <Alert severity="info">
+      <AlertTitle>{alertTitle}</AlertTitle>
+      {alertText}
+      <Typography
+        style={{ textDecoration: 'none' }}
+        to={route}
+        component={Link}
+      >
+        <strong>{pageName}</strong>
+      </Typography>
+    </Alert>
+  );
+};

--- a/src/lib/firebase/firebase.config.js
+++ b/src/lib/firebase/firebase.config.js
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app';
+import * as firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
 
@@ -17,5 +17,3 @@ firebase.initializeApp(firebaseConfig);
 
 export const auth = firebase.auth();
 export const firestore = firebase.firestore();
-
-export default firebase;

--- a/src/pages/study-group/StudyGroupPage.jsx
+++ b/src/pages/study-group/StudyGroupPage.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 
-import { modules } from '../../models/Module';
 import { StudyGroup } from '../../models/StudyGroup';
 import {
   selectMyGroups,
@@ -24,6 +23,7 @@ import { Searchbar } from '../../components/Searchbar/Searchbar';
 import { UpcomingGroupList } from '../../components/UpcomingGroupList/UpcomingGroupList';
 import { StudyGroupSection } from '../../components/StudyGroupSection/StudyGroupSection';
 import { StudyGroupDialog } from '../../components/StudyGroupDialog/StudyGroupDialog';
+import { InfoAlert } from '../../components/shared/InfoAlert';
 
 const StudyGroupPageComponent = ({
   myGroups,
@@ -38,11 +38,11 @@ const StudyGroupPageComponent = ({
     // fetch my, live and module-specific study groups
     // call this when variables change by providing the varaibles in the second argument
     // this behaves like componentDidMount
-    modules.forEach((module) => {
-      readGroupsByModule(module.id);
-    });
     if (currentUser && currentUser.id != null) {
       readMyGroups(currentUser.id);
+      currentUser.modules.forEach((moduleCode) =>
+        readGroupsByModule(moduleCode)
+      );
     }
   }, [currentUser, readGroupsByModule, readMyGroups]);
 
@@ -65,7 +65,29 @@ const StudyGroupPageComponent = ({
                 </Grid>
               </Grid>
             </Grid>
-            {myGroups.length > 0 && (
+            {currentUser == null && (
+              <Grid xs={12} item>
+                <Box mt={3} />
+                <InfoAlert
+                  alertTitle="You are not logged in"
+                  alertText="Please log in to your account on "
+                  route="/login"
+                  pageName="Login page"
+                />
+              </Grid>
+            )}
+            {currentUser && currentUser.modules.length === 0 && (
+              <Grid xs={12} item>
+                <Box mt={3} />
+                <InfoAlert
+                  alertTitle="You don't have any modules"
+                  alertText="Please add your modules on "
+                  route="/dashboard"
+                  pageName="Dashboard page"
+                />
+              </Grid>
+            )}
+            {currentUser && myGroups.length > 0 && (
               <Grid xs={12} item>
                 <StudyGroupSection
                   sectionTitle="My groups"
@@ -73,14 +95,15 @@ const StudyGroupPageComponent = ({
                 />
               </Grid>
             )}
-            {modules.map((module, index) => (
-              <Grid xs={12} key={index} item>
-                <StudyGroupSection
-                  sectionTitle={module.id}
-                  sectionData={studyGroupsByModule(module.id)}
-                />
-              </Grid>
-            ))}
+            {currentUser &&
+              currentUser.modules.map((moduleCode) => (
+                <Grid xs={12} key={moduleCode} item>
+                  <StudyGroupSection
+                    sectionTitle={moduleCode}
+                    sectionData={studyGroupsByModule(moduleCode)}
+                  />
+                </Grid>
+              ))}
           </Grid>
         </Grid>
         <Hidden smDown>

--- a/src/redux/studyGroup/studyGroup.reducer.js
+++ b/src/redux/studyGroup/studyGroup.reducer.js
@@ -13,6 +13,11 @@ export const studyGroupReducer = (state = INITIAL_STATE, action) => {
       return {
         ...state,
         error: null,
+        myGroups: [...state.myGroups, action.payload],
+        [action.payload.moduleCode]: [
+          ...state[action.payload.moduleCode],
+          action.payload,
+        ],
         createSuccess: true,
       };
 

--- a/src/redux/studyGroup/studyGroup.saga.js
+++ b/src/redux/studyGroup/studyGroup.saga.js
@@ -33,6 +33,8 @@ export function* createGroupGenerator({ payload }) {
       data: payload,
       setId: true,
     });
+    console.log('payload: ', payload);
+    // fetch module groups and my groups after create Success
     yield put(createGroupSuccess(payload));
   } catch (error) {
     yield put(createGroupError(error));

--- a/src/redux/user/user.saga.js
+++ b/src/redux/user/user.saga.js
@@ -36,7 +36,7 @@ export function* storeUserToFirestore(user) {
       collection: collectionName,
       data: userData,
       setId: false,
-      docId: user.uid,
+      docId: userData.id,
     });
     yield storeUserToReducer(userData);
   } catch (error) {

--- a/src/services/firestore.js
+++ b/src/services/firestore.js
@@ -93,7 +93,7 @@ export const addDocument = async ({ collection, data, setId, docId }) => {
     data.id = ref.id;
     await ref.set(data);
   } else {
-    await firestore.collection(collection).doc(docId).addDocument(data);
+    await firestore.collection(collection).doc(docId).set(data);
   }
 };
 

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -8,7 +8,7 @@ export const formatTime = (startTime, endTime) => {
   if (startTime.isBefore(now) && endTime.isAfter(now)) {
     return 'Until ' + endTime.format('hh:mm A');
   } else {
-    return 'At ' + endTime.format('hh:mm A');
+    return 'At ' + startTime.format('hh:mm A');
   }
 };
 


### PR DESCRIPTION
## What?
Integrate user's modules in fetching the available study groups and create study groups based on the user's modules.
Fix start time and end time bugs when creating a study group.
## Why?
Display only the modules that are studying by the user and restrict the user to create study groups related to their modules.
Ensure the start time is before the end time when creating a study group.
## How?
Get the user's modules from Firestore and filter the available study groups by user's modules. Restrict the module options to only the user's modules when creating a study group. 
Use React Hook Form and Moment.js to validate the start time and end time.
## Testing?
## Screenshots (optional)
Refer to pull request #36 Implement creating a study group and fetching study groups from Firestore.
## Anything Else?
