### PR TITLE
Refine Q&A thread UI/UX and fix minor bugs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -49,7 +49,7 @@ const App = ({ checkUserSession, currentUser }) => {
               path="/virtual-group"
               render={() => <VirtualGroupPage />}
             />
-            <Route path="/qa-thread" render={() => <QAThreadPage />} />
+            <Route exact path="/qa-thread" render={() => <QAThreadPage />} />
             <Route path="/dashboard" render={() => <DashboardPage />} />
             <Route
               path="/login"
@@ -70,8 +70,8 @@ const App = ({ checkUserSession, currentUser }) => {
               )}
             />
             <Route
-              path="/qa-thread-module"
-              render={() => <QAThreadModulePage />}
+              path="/qa-thread/:moduleCode"
+              render={() => <QAThreadModulePage currentUser={currentUser} />}
             />
             <Route
               exact

--- a/src/components/QAThreadDialog/QAThreadForm.jsx
+++ b/src/components/QAThreadDialog/QAThreadForm.jsx
@@ -67,7 +67,6 @@ const QAThreadFormComponent = ({
       if (threadError) {
         clearThreadError();
       }
-      console.log('createSuccess from form: ', createSuccess);
       if (createSuccess) {
         clearCreateSuccess();
       }
@@ -116,7 +115,7 @@ const QAThreadFormComponent = ({
               }
               onChange={([, data]) => data}
               name="module"
-              defaultValue={modulePage ? module : undefined}
+              defaultValue={modulePage ? module : {}}
               control={control}
               rules={{ required: 'Please select module' }}
             />

--- a/src/components/QAThreadModule/QAThreadModule.jsx
+++ b/src/components/QAThreadModule/QAThreadModule.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-// import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import { Typography } from '@material-ui/core';
 import { Box } from '@material-ui/core';
@@ -36,7 +36,7 @@ const componentStyles = makeStyles({
     },
     '&::-webkit-scrollbar-thumb:hover': {
       borderRadius: 8,
-      background: '#421cf8',
+      background: 'gray',
     },
   },
 });
@@ -60,7 +60,7 @@ export const QAThreadModule = ({ moduleCode, threads, currentUser }) => {
         <IconButton onClick={handleClick}>
           {open ? <ExpandLess /> : <ExpandMore />}
         </IconButton>
-        <Button /*component={NavLink} to="/qa-thread-module"*/>
+        <Button component={NavLink} to={`qa-thread/${moduleCode}`}>
           <Typography variant="body1">{moduleCode}</Typography>
         </Button>
       </Box>
@@ -78,7 +78,7 @@ export const QAThreadModule = ({ moduleCode, threads, currentUser }) => {
             ) : (
               <Box width={1}>
                 <Alert severity="info">
-                  Looks like there is no any Q&A thread yet...
+                  No activity detected on this Module :(
                 </Alert>
               </Box>
             )}

--- a/src/components/Searchbar/Searchbar.jsx
+++ b/src/components/Searchbar/Searchbar.jsx
@@ -23,9 +23,11 @@ export const Searchbar = ({ currentUser, searchCallback }) => {
   const theme = useTheme();
   const classes = useStyles();
   const matchXs = useMediaQuery(theme.breakpoints.up('xs'));
-  const options = currentUser.modules
-    .filter((moduleCode) => moduleCode !== 'MOD1001')
-    .map((moduleCode) => Module.getModuleByModuleCode(moduleCode));
+  const options = currentUser
+    ? currentUser.modules
+        .filter((moduleCode) => moduleCode !== 'MOD1001')
+        .map((moduleCode) => Module.getModuleByModuleCode(moduleCode))
+    : [];
   const handleSelect = (_, value, reason) => {
     // modules or locations are selected
     // pass back the search data

--- a/src/components/VirtualGroupDialog/VirtualGroupDialog.jsx
+++ b/src/components/VirtualGroupDialog/VirtualGroupDialog.jsx
@@ -70,7 +70,7 @@ const VirtualGroupDialogComponent = ({
   return (
     <div>
       {screenSmall ? (
-        <IconButton onClick={handleClickOpen}>
+        <IconButton disabled={!currentUser} onClick={handleClickOpen}>
           <AddCircleRoundedIcon style={{ fontSize: 44 }} />
         </IconButton>
       ) : (
@@ -79,6 +79,7 @@ const VirtualGroupDialogComponent = ({
           size="small"
           variant="contained"
           onClick={handleClickOpen}
+          disabled={!currentUser}
         >
           Create
         </Button>

--- a/src/components/VirtualGroupDialog/VirtualGroupForm.jsx
+++ b/src/components/VirtualGroupDialog/VirtualGroupForm.jsx
@@ -84,7 +84,6 @@ const VirtualGroupFormComponent = ({
       if (groupError) {
         clearGroupError();
       }
-      console.log('createSuccess from form: ', createSuccess);
       if (createSuccess) {
         clearCreateSuccess();
       }

--- a/src/components/YourQAThread/YourQAThread.jsx
+++ b/src/components/YourQAThread/YourQAThread.jsx
@@ -1,20 +1,28 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { materialStyles } from '../../styles/material.styles';
+import { makeStyles } from '@material-ui/core/styles';
 import { Typography } from '@material-ui/core';
 import { Button } from '@material-ui/core';
 import { Box } from '@material-ui/core';
 import { Paper } from '@material-ui/core';
 import { Grid } from '@material-ui/core';
 
+const componentStyles = makeStyles({
+  card: {
+    padding: 16,
+    // orange: QA threads
+    backgroundColor: 'rgba(250, 190, 88, 0.3)',
+  },
+});
+
 export const YourQAThread = ({ thread }) => {
-  const materialClasses = materialStyles();
+  const componentClasses = componentStyles();
 
   return (
     <Box
       component={Paper}
-      className={materialClasses.paper}
+      className={componentClasses.card}
       mb="5px"
       height={0.45}
       width={1}

--- a/src/components/YourQAThreadSmall/YourQAThreadSmall.jsx
+++ b/src/components/YourQAThreadSmall/YourQAThreadSmall.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { Box } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { Typography } from '@material-ui/core';
 import { List, ListItem } from '@material-ui/core';
@@ -12,7 +13,6 @@ const componentStyles = makeStyles({
     borderWidth: 1,
     borderColor: 'rgba(0, 0, 0, .4)',
     borderRadius: 5,
-    width: 332,
   },
 });
 
@@ -32,7 +32,11 @@ const Thread = ({ thread }) => {
             </Typography>
           </Grid>
           <Grid item xs={3}>
-            <Typography variant="button">{thread.moduleCode}</Typography>
+            <Box display="flex" maxWidth={1} justifyContent="flex-end">
+              <Typography variant="button" align="right">
+                {thread.moduleCode}
+              </Typography>
+            </Box>
           </Grid>
         </Grid>
       </ListItem>
@@ -44,7 +48,7 @@ export const YourQAThreadSmall = ({ myThreads }) => {
   const component = componentStyles();
   return (
     <div>
-      <List className={component.root}>
+      <List width={1} className={component.root}>
         {myThreads.map((thread, index) => (
           <Thread key={index} thread={thread} />
         ))}

--- a/src/pages/dashboard/DashboardPage.jsx
+++ b/src/pages/dashboard/DashboardPage.jsx
@@ -9,6 +9,14 @@ import { selectMyGroups } from '../../redux/studyGroup/studyGroup.selector';
 import { readMyGroups } from '../../redux/studyGroup/studyGroup.action';
 import { selectMyVirtualGroups } from '../../redux/virtualGroup/virtualGroup.selector';
 import { readMyVirtualGroups } from '../../redux/virtualGroup/virtualGroup.action';
+import {
+  selectMyQAThreads,
+  selectMyStarredQAThreads,
+} from '../../redux/qaThread/qaThread.selector';
+import {
+  readMyQAThreads,
+  readMyStarredQAThreads,
+} from '../../redux/qaThread/qaThread.action';
 
 import { makeStyles } from '@material-ui/core/styles';
 import { materialStyles } from '../../styles/material.styles';
@@ -31,6 +39,7 @@ import { Searchbar } from '../../components/Searchbar/Searchbar';
 import { AddModuleDialog } from '../../components/AddModuleDialog/AddModuleDialog';
 import { StudyGroupSection } from '../../components/StudyGroupSection/StudyGroupSection';
 import { VirtualGroupCard } from '../../components/VirtualGroupCard/VirtualGroupCard';
+import { QAThreadCard } from '../../components/QAThreadCard/QAThreadCard';
 
 const dashboardStyles = makeStyles({
   cardsSection: {
@@ -57,6 +66,10 @@ const DashboardPageComponent = ({
   readMyStudyGroups,
   myVirtualGroups,
   readMyVirtualGroups,
+  myThreads,
+  readMyThreads,
+  starredThreads,
+  readMyStarredThreads,
 }) => {
   const dashboardClasses = dashboardStyles();
   const materialClasses = materialStyles();
@@ -80,8 +93,16 @@ const DashboardPageComponent = ({
     if (currentUser && currentUser.id != null) {
       readMyStudyGroups(currentUser.id);
       readMyVirtualGroups(currentUser.id);
+      readMyThreads(currentUser.id);
+      readMyStarredThreads(currentUser.id);
     }
-  }, [currentUser, readMyStudyGroups, readMyVirtualGroups]);
+  }, [
+    currentUser,
+    readMyStudyGroups,
+    readMyVirtualGroups,
+    readMyThreads,
+    readMyStarredThreads,
+  ]);
 
   return (
     <Box className={materialClasses.root}>
@@ -184,7 +205,76 @@ const DashboardPageComponent = ({
               </Paper>
             </Grid>
             <Grid xs={12} item>
-              <Paper className={materialClasses.paper}>Q&A Threads</Paper>
+              <Paper className={materialClasses.paper}>
+                <Grid container>
+                  <Grid item xs={12}>
+                    <Box mb={1}>
+                      <Typography variant="h6">
+                        {capSentence('My Q&A threads')}
+                      </Typography>
+                    </Box>
+                  </Grid>
+                  <Grid xs={12}>
+                    <Box
+                      overflow="auto"
+                      className={dashboardClasses.cardsSection}
+                    >
+                      {myThreads && myThreads.length > 0 ? (
+                        myThreads.map((thread, index) => (
+                          <QAThreadCard
+                            currentUser={currentUser}
+                            key={index}
+                            thread={thread}
+                          />
+                        ))
+                      ) : (
+                        <Box width={1}>
+                          <Alert severity="info">
+                            Whoops! Looks like you have not initiated any Q&A
+                            thread yet.
+                          </Alert>
+                        </Box>
+                      )}
+                    </Box>
+                  </Grid>
+                </Grid>
+              </Paper>
+            </Grid>
+            <Grid xs={12} item>
+              <Paper className={materialClasses.paper}>
+                <Grid container>
+                  <Grid item xs={12}>
+                    <Box mb={1}>
+                      <Typography variant="h6">
+                        {capSentence('Starred Q&A threads')}
+                      </Typography>
+                    </Box>
+                  </Grid>
+                  <Grid xs={12}>
+                    <Box
+                      overflow="auto"
+                      className={dashboardClasses.cardsSection}
+                    >
+                      {starredThreads && starredThreads.length > 0 ? (
+                        starredThreads.map((thread, index) => (
+                          <QAThreadCard
+                            currentUser={currentUser}
+                            key={index}
+                            thread={thread}
+                          />
+                        ))
+                      ) : (
+                        <Box width={1}>
+                          <Alert severity="info">
+                            Whoops! Looks like you have not starred any Q&A
+                            thread yet.
+                          </Alert>
+                        </Box>
+                      )}
+                    </Box>
+                  </Grid>
+                </Grid>
+              </Paper>
             </Grid>
           </Grid>
         </Grid>
@@ -217,12 +307,16 @@ const DashboardPageComponent = ({
 const mapStateToProps = createStructuredSelector({
   myStudyGroups: selectMyGroups,
   myVirtualGroups: selectMyVirtualGroups,
+  myThreads: selectMyQAThreads,
+  starredThreads: selectMyStarredQAThreads,
   currentUser: selectCurrentUser,
 });
 
 const mapDispatchToProps = (dispatch) => ({
   readMyStudyGroups: (userId) => dispatch(readMyGroups(userId)),
   readMyVirtualGroups: (userId) => dispatch(readMyVirtualGroups(userId)),
+  readMyThreads: (userId) => dispatch(readMyQAThreads(userId)),
+  readMyStarredThreads: (userId) => dispatch(readMyStarredQAThreads(userId)),
 });
 
 export const DashboardPage = connect(

--- a/src/pages/qa-thread/QAThreadPage.jsx
+++ b/src/pages/qa-thread/QAThreadPage.jsx
@@ -37,9 +37,6 @@ const liveThreadsStyles = makeStyles({
     flexDirection: 'column',
     alignItems: 'flex-start',
     marginTop: 20,
-    '&::-webkit-scrollbar': {
-      display: 'none',
-    },
   },
 });
 
@@ -51,7 +48,14 @@ const yourThreadsStyles = makeStyles({
     alignItems: 'flex-start',
     flexDirection: 'column',
     '&::-webkit-scrollbar': {
-      display: 'none',
+      width: '6px',
+    },
+    '&::-webkit-scrollbar-track': {
+      background: 'transparent',
+    },
+    '&::-webkit-scrollbar-thumb:hover': {
+      borderRadius: 8,
+      backgroundColor: 'gray',
     },
   },
 });
@@ -99,9 +103,7 @@ const QAThreadPageComponent = ({
 
   // filter user modules by searchbar selection(s)
   const searchCallback = (searchData) => {
-    console.log('search:', searchData);
     if (searchData.value !== null) {
-      console.log('searchData.value:', searchData.value);
       // const results = currentUser.modules.filter((moduleCode) =>
       //   searchData.value.map((module) => module.option).includes(moduleCode)
       // );
@@ -128,17 +130,23 @@ const QAThreadPageComponent = ({
   return (
     <Box className={materialClasses.root}>
       <Hidden mdUp>
-        <Popper open={open} anchorEl={anchorEl} placement="bottom">
-          <YourQAThreadSmall myThreads={myThreads} />
+        <Popper
+          open={open}
+          style={{ width: '94%' }}
+          anchorEl={anchorEl}
+          placement="bottom"
+        >
+          {currentUser && <YourQAThreadSmall myThreads={myThreads} />}
         </Popper>
       </Hidden>
       <Hidden mdUp>
         <Popper
           open={anotherOpen}
+          style={{ width: '94%' }}
           anchorEl={anotherAnchorEl}
           placement="bottom"
         >
-          <YourQAThreadSmall myThreads={starredThreads} />
+          {currentUser && <YourQAThreadSmall myThreads={starredThreads} />}
         </Popper>
       </Hidden>
       <Grid container spacing={3} justify="space-between">
@@ -147,6 +155,7 @@ const QAThreadPageComponent = ({
             <Box my="4px">
               <Button
                 onClick={handleClick}
+                disabled={!currentUser}
                 variant="outlined"
                 fullWidth
                 size="small"
@@ -159,6 +168,7 @@ const QAThreadPageComponent = ({
             <Box my="4px">
               <Button
                 onClick={handleAnotherClick}
+                disabled={!currentUser}
                 variant="outlined"
                 fullWidth
                 size="small"

--- a/src/pages/qa-thread/module/QAThreadModulePage.jsx
+++ b/src/pages/qa-thread/module/QAThreadModulePage.jsx
@@ -1,17 +1,20 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
+import { useParams } from 'react-router-dom';
 
-import { QAThread } from '../../../models/QAThread';
 import {
   selectMyQAThreads,
   selectQAThreadsByModule,
+  selectMyStarredQAThreads,
 } from '../../../redux/qaThread/qaThread.selector';
 import {
   readMyQAThreads,
+  readMyStarredQAThreads,
   readQAThreadsByModule,
 } from '../../../redux/qaThread/qaThread.action';
-import { selectCurrentUser } from '../../../redux/user/user.selector';
 
+import { useTheme } from '@material-ui/core/styles';
+import { useMediaQuery } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { Typography } from '@material-ui/core';
 import { Box } from '@material-ui/core';
@@ -19,10 +22,14 @@ import { Grid } from '@material-ui/core';
 import { Hidden } from '@material-ui/core';
 import { Button } from '@material-ui/core';
 import { Popper } from '@material-ui/core';
-import { ClickAwayListener } from '@material-ui/core';
+import Alert from '@material-ui/lab/Alert';
+// import { ClickAwayListener } from '@material-ui/core';
 
+import { CustomAlert } from '../../../components/shared/CustomAlert';
+import { Module } from '../../../models/Module';
 import { materialStyles } from '../../../styles/material.styles';
-import { Searchbar } from '../../../components/Searchbar/Searchbar';
+// import { Searchbar } from '../../../components/Searchbar/Searchbar';
+import { QAThreadDialog } from '../../../components/QAThreadDialog/QAThreadDialog';
 import { YourQAThread } from '../../../components/YourQAThread/YourQAThread';
 import { YourQAThreadSmall } from '../../../components/YourQAThreadSmall/YourQAThreadSmall';
 import { QAThreadCard } from '../../../components/QAThreadCard/QAThreadCard';
@@ -34,9 +41,6 @@ const liveThreadsStyles = makeStyles({
     flexDirection: 'column',
     justifyContent: 'flex-start',
     marginTop: 20,
-    '&::-webkit-scrollbar': {
-      display: 'none',
-    },
   },
 });
 
@@ -48,21 +52,34 @@ const yourThreadsStyles = makeStyles({
     alignItems: 'flex-start',
     flexDirection: 'column',
     '&::-webkit-scrollbar': {
-      display: 'none',
+      width: '6px',
+    },
+    '&::-webkit-scrollbar-track': {
+      background: 'transparent',
+    },
+    '&::-webkit-scrollbar-thumb:hover': {
+      borderRadius: 8,
+      backgroundColor: 'gray',
     },
   },
 });
 
 const QAThreadModulePageComponent = ({
   myThreads,
+  starredThreads,
   currentUser,
   readMyThreads,
+  readMyStarredThreads,
   readThreadsByModule,
   qaThreadsByModule,
 }) => {
+  const theme = useTheme();
+  const xs = useMediaQuery(theme.breakpoints.down('xs'));
   const materialClasses = materialStyles();
   const liveThreadsClasses = liveThreadsStyles();
   const yourThreadsClasses = yourThreadsStyles();
+  const { moduleCode } = useParams();
+  const module = Module.getModuleByModuleCode(moduleCode);
 
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [open, setOpen] = React.useState(false);
@@ -79,6 +96,7 @@ const QAThreadModulePageComponent = ({
     setAnotherAnchorEl(event.currentTarget);
   };
 
+  /*
   const handleClickAway = () => {
     setOpen(false);
   };
@@ -86,75 +104,136 @@ const QAThreadModulePageComponent = ({
   const handleAnotherClickAway = () => {
     setAnotherOpen(false);
   };
+  */
 
   useEffect(() => {
-    // fetch open threads under the module and my threads
-    readThreadsByModule('MOD1001');
+    // fetch open threads under the module, my threads and starred threads
     if (currentUser && currentUser.id != null) {
       readMyThreads(currentUser.id);
+      readMyStarredThreads(currentUser.id);
+      readThreadsByModule(moduleCode);
     }
-  }, [currentUser, readThreadsByModule, readMyThreads]);
+  }, [
+    moduleCode,
+    currentUser,
+    readThreadsByModule,
+    readMyThreads,
+    readMyStarredThreads,
+  ]);
 
-  const threads = qaThreadsByModule('MOD1001');
+  const threads = qaThreadsByModule(moduleCode);
 
   return (
     <Box className={materialClasses.root}>
       <Hidden mdUp>
-        <Popper open={open} anchorEl={anchorEl} placement="bottom">
-          <YourQAThreadSmall />
+        <Popper
+          open={open}
+          style={{ width: '94%' }}
+          anchorEl={anchorEl}
+          placement="bottom"
+        >
+          {currentUser && <YourQAThreadSmall myThreads={myThreads} />}
         </Popper>
       </Hidden>
       <Hidden mdUp>
         <Popper
           open={anotherOpen}
+          style={{ width: '94%' }}
           anchorEl={anotherAnchorEl}
           placement="bottom"
         >
-          <YourQAThreadSmall />
+          {currentUser && <YourQAThreadSmall myThreads={starredThreads} />}
         </Popper>
       </Hidden>
       <Grid container spacing={3} justify="space-between">
         <Grid item xs={12} md={8}>
-          <Typography variant="h4" align="center">
-            MOD1001
-          </Typography>
+          <Box mb={!xs ? 2 : 0} mt={xs ? 1 : 0}>
+            <Typography variant="h4" align="center">
+              {moduleCode}
+            </Typography>
+          </Box>
           <Hidden mdUp>
             <Box my="4px">
-              <ClickAwayListener onClickAway={handleClickAway}>
-                <Button
-                  onClick={handleClick}
-                  variant="outlined"
-                  fullWidth
-                  size="small"
-                >
-                  <Typography variant="button">Starred threads</Typography>
-                </Button>
-              </ClickAwayListener>
+              <Grid container alignItems="center">
+                <Grid item xs={10}>
+                  <Button
+                    onClick={handleClick}
+                    disabled={!currentUser}
+                    variant="outlined"
+                    fullWidth
+                    size="small"
+                  >
+                    <Typography variant="button">My threads</Typography>
+                  </Button>
+                </Grid>
+                <Grid item xs={2}>
+                  <QAThreadDialog
+                    modulePage
+                    module={{
+                      moduleCode: module.moduleCode,
+                      title: module.title,
+                    }}
+                  />
+                </Grid>
+              </Grid>
             </Box>
           </Hidden>
           <Hidden mdUp>
             <Box my="4px">
-              <ClickAwayListener onClickAway={handleAnotherClickAway}>
-                <Button
-                  onClick={handleAnotherClick}
-                  variant="outlined"
-                  fullWidth
-                  size="small"
-                >
-                  <Typography variant="button">Recent threads</Typography>
-                </Button>
-              </ClickAwayListener>
+              <Button
+                onClick={handleAnotherClick}
+                disabled={!currentUser}
+                variant="outlined"
+                fullWidth
+                size="small"
+              >
+                <Typography variant="button">Starred threads</Typography>
+              </Button>
             </Box>
           </Hidden>
           <Grid container height={1} spacing={1}>
             <Grid item xs={12}>
-              <Searchbar searchOptions={QAThread.searchOptions} />
+              {!xs && (
+                <Grid item xs={12}>
+                  <Grid container justify="center">
+                    <Grid item md={4}>
+                      <QAThreadDialog
+                        modulePage
+                        module={{
+                          moduleCode: module.moduleCode,
+                          title: module.title,
+                        }}
+                      />
+                    </Grid>
+                  </Grid>
+                </Grid>
+              )}
             </Grid>
             <Grid item xs={12} wrap="nowrap">
               <Box width={1} className={liveThreadsClasses.list}>
-                {threads.map((thread, index) => (
-                  <QAThreadCard key={index} thread={thread} modulePage />
-                ))}
+                {currentUser === null && (
+                  <Grid xs={12} item>
+                    <Box mt={3} />
+                    <CustomAlert
+                      severity="info"
+                      alertTitle="You are not logged in"
+                      alertText="Please log in to your account on "
+                      route="/login"
+                      pageName="Login page"
+                    />
+                  </Grid>
+                )}
+                {currentUser && threads && threads.length === 0 && (
+                  <Alert severity="info">
+                    No thread detected on this Module. Feel free to initiate the
+                    first ever thread to tackle tasks on this Module!
+                  </Alert>
+                )}
+                {currentUser &&
+                  threads &&
+                  threads.map((thread, index) => (
+                    <QAThreadCard key={index} thread={thread} modulePage />
+                  ))}
               </Box>
             </Grid>
           </Grid>
@@ -163,19 +242,25 @@ const QAThreadModulePageComponent = ({
           <Grid item md={3}>
             <Box my="10px">
               <Typography variant="h6" align="center">
+                My threads
+              </Typography>
+            </Box>
+            <Box className={yourThreadsClasses.list}>
+              {currentUser &&
+                myThreads.map((thread, index) => (
+                  <YourQAThread key={index} thread={thread} />
+                ))}
+            </Box>
+            <Box my={2}>
+              <Typography variant="h6" align="center">
                 Starred threads
               </Typography>
             </Box>
             <Box className={yourThreadsClasses.list}>
-              <YourQAThread />
-            </Box>
-            <Box my={2}>
-              <Typography variant="h6" align="center">
-                Recent threads
-              </Typography>
-            </Box>
-            <Box className={yourThreadsClasses.list}>
-              <YourQAThread />
+              {currentUser &&
+                starredThreads.map((thread, index) => (
+                  <YourQAThread key={index} thread={thread} />
+                ))}
             </Box>
           </Grid>
         </Hidden>
@@ -186,12 +271,13 @@ const QAThreadModulePageComponent = ({
 
 const mapStateToProps = (state) => ({
   myThreads: selectMyQAThreads(state),
-  currentUser: selectCurrentUser(state),
+  starredThreads: selectMyStarredQAThreads(state),
   qaThreadsByModule: (moduleCode) => selectQAThreadsByModule(moduleCode)(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({
   readMyThreads: (userId) => dispatch(readMyQAThreads(userId)),
+  readMyStarredThreads: (userId) => dispatch(readMyStarredQAThreads(userId)),
   readThreadsByModule: (moduleCode) =>
     dispatch(readQAThreadsByModule(moduleCode)),
 });

--- a/src/pages/virtual-group/VirtualGroupPage.jsx
+++ b/src/pages/virtual-group/VirtualGroupPage.jsx
@@ -72,9 +72,9 @@ const VirtualGroupPageComponent = ({
 
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [open, setOpen] = React.useState(false);
-  const realUserModules = currentUser.modules.filter(
-    (moduleCode) => moduleCode !== 'MOD1001'
-  );
+  const realUserModules = currentUser
+    ? currentUser.modules.filter((moduleCode) => moduleCode !== 'MOD1001')
+    : [];
   const [searchQueries, setSearchQueries] = React.useState(
     currentUser ? realUserModules : []
   );
@@ -100,11 +100,11 @@ const VirtualGroupPageComponent = ({
     // fetch recruiting groups by module and my groups
     // call this when variables change by providing the variables in the second argument
     // this behaves like componentDidMount
-    currentUser.modules.forEach((moduleCode) => {
-      readGroupsByModule(moduleCode);
-    });
     if (currentUser && currentUser.id != null) {
       readMyGroups(currentUser.id);
+      currentUser.modules.forEach((moduleCode) => {
+        readGroupsByModule(moduleCode);
+      });
     }
   }, [currentUser, readGroupsByModule, readMyGroups]);
 
@@ -119,16 +119,19 @@ const VirtualGroupPageComponent = ({
               anchorEl={anchorEl}
               placement="bottom"
             >
-              <YourGroupsSmall
-                currentUser={currentUser}
-                yourGroups={myGroups}
-              />
+              {currentUser && (
+                <YourGroupsSmall
+                  currentUser={currentUser}
+                  yourGroups={myGroups}
+                />
+              )}
             </Popper>
           </Hidden>
           <Hidden mdUp>
             <Box my="4px">
               <Button
                 onClick={handleClick}
+                disabled={!currentUser}
                 variant="outlined"
                 fullWidth
                 size="small"

--- a/src/pages/virtual-group/module/VirtualGroupModulePage.jsx
+++ b/src/pages/virtual-group/module/VirtualGroupModulePage.jsx
@@ -24,6 +24,7 @@ import { Popper } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
 
 //import { Searchbar } from '../../../components/Searchbar/Searchbar';
+import { CustomAlert } from '../../../components/shared/CustomAlert';
 import { Module } from '../../../models/Module';
 import { materialStyles } from '../../../styles/material.styles';
 import { YourGroupsSmall } from '../../../components/YourVirtualGroupsSmall/YourVirtualGroupsSmall';
@@ -113,17 +114,25 @@ export const VirtualGroupModulePageComponent = ({
             </Typography>
           </Box>
           <Hidden mdUp>
-            <Popper open={open} anchorEl={anchorEl} placement="bottom-end">
-              <YourGroupsSmall
-                currentUser={currentUser}
-                yourGroups={myGroups}
-              />
+            <Popper
+              open={open}
+              style={{ width: '94%' }}
+              anchorEl={anchorEl}
+              placement="bottom-end"
+            >
+              {currentUser && (
+                <YourGroupsSmall
+                  currentUser={currentUser}
+                  yourGroups={myGroups}
+                />
+              )}
             </Popper>
             <Box width={1} mb="4px">
               <Grid container alignItems="center">
                 <Grid item xs={10}>
                   <Button
                     onClick={handleClick}
+                    disabled={!currentUser}
                     variant="outlined"
                     fullWidth
                     size="small"
@@ -134,7 +143,10 @@ export const VirtualGroupModulePageComponent = ({
                 <Grid item xs={2}>
                   <VirtualGroupDialog
                     modulePage
-                    module={{ id: 'MOD1001', name: 'Test Module' }}
+                    module={{
+                      moduleCode: module.moduleCode,
+                      title: module.title,
+                    }}
                   />
                 </Grid>
               </Grid>
@@ -163,7 +175,20 @@ export const VirtualGroupModulePageComponent = ({
             )}
           </Grid>
           <Box className={recruitingGroupsClasses.list} width={1}>
-            {groups &&
+            {currentUser === null && (
+              <Grid xs={12} item>
+                <Box mt={3} />
+                <CustomAlert
+                  severity="info"
+                  alertTitle="You are not logged in"
+                  alertText="Please log in to your account on "
+                  route="/login"
+                  pageName="Login page"
+                />
+              </Grid>
+            )}
+            {currentUser &&
+              groups &&
               !xs &&
               recruitingGroups.map((virtualGroup, index) => (
                 <VirtualGroupCard
@@ -173,7 +198,7 @@ export const VirtualGroupModulePageComponent = ({
                   groupData={virtualGroup}
                 />
               ))}
-            {groups && xs && (
+            {currentUser && groups && xs && (
               <Grid container>
                 {recruitingGroups.map((virtualGroup, index) => (
                   <Grid item xs={12} key={index}>


### PR DESCRIPTION
## What?
- Add color to Q&A thread cards
- Implement display latest message on Q&A thread cards
- Update scrollbars on Q&A Thread pages
- Implement reading my threads and starred threads on the dashboard page
- Implement module page CRUD features
- Fix searchbar fetching user data when user is not logged in
- Disable buttons when user is not logged in
## Why?
- Feature enhancement for #62
- Improve UI/UX for Q&A thread pages and virtual group pages
- Fix searchbar crashing the website after logging out
## How?
**1. Minor UI/UX improvements**
Fix UI inconsistencies across virtual group pages. Apply background color to Q&A thread cards to distinguish them from other cards. Call `readRecentMessages` from `messages.js` on the card component to obtain the latest message and display it on Q&A thread cards and display placeholder text if the thread does not have any messages. Update scrollbars on Q&A thread lists to enforce UI consistencies throughout the app. Add custom alerts to sections which are empty. Disable create group/thread buttons as well as my groups/threads buttons on mobile screens when user is logged out.

**2. Module page**
Introduce new routes and dispatch appropriate CRUD actions/selectors on `QAThreadModulePage` so that each module has a unique and fully functional module page which can be accessed by clicking on the module code on each recruiting group section on the main page. Much like their virtual group counterparts, the Q&A thread module pages allow users to gain access to their threads, their starred threads and create new threads, as well as see open threads under the module.

**3. My threads and starred threads on the dashboard page**
Dispatch appropriate actions to read the user's threads and the user's starred threads and use appropriate selectors to obtain said threads to display them below the virtual groups section so that users can access their threads and starred threads conveniently from the dashboard page.

**4. Bug fixes**
Add checking on the `Searchbar` component so that it does not fetch user modules when the user is logged out.
## Testing?
## Screenshots (optional)
**Updated UI**
![localhost_3000_qa-thread(Laptop with HiDPI screen) (1)](https://user-images.githubusercontent.com/65291543/88282510-4b0ad180-cd1c-11ea-8ec4-bc6b06982db0.png)

**Module page**
![localhost_3000_qa-thread(Laptop with HiDPI screen) (2)](https://user-images.githubusercontent.com/65291543/88282613-7988ac80-cd1c-11ea-8eda-19dd89d7f81e.png)

**Q&A threads on the dashboard page**
![localhost_3000_qa-thread(Laptop with HiDPI screen) (3)](https://user-images.githubusercontent.com/65291543/88282691-9ae99880-cd1c-11ea-915b-faa7dd1ac81a.png)
## Anything Else?
